### PR TITLE
Use reload of sensu-enterprise service rather than restart

### DIFF
--- a/manifests/enterprise.pp
+++ b/manifests/enterprise.pp
@@ -95,6 +95,13 @@ class sensuclassic::enterprise (
           Class['sensuclassic::package'],
         ],
       }
+
+      exec { 'sensu-enterprise-reload':
+        path        => '/usr/bin:/bin:/usr/sbin:/sbin',
+        command     => 'service sensu-enterprise reload',
+        refreshonly => true,
+        require     => Service['sensu-enterprise'],
+      }
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -586,7 +586,7 @@ class sensuclassic (
   }
 
   if $enterprise and $manage_services {
-    $enterprise_service = Service['sensu-enterprise']
+    $enterprise_service = Exec['sensu-enterprise-reload']
   } else {
     $enterprise_service = undef
   }

--- a/spec/classes/sensuclassic_enterprise_spec.rb
+++ b/spec/classes/sensuclassic_enterprise_spec.rb
@@ -30,6 +30,7 @@ describe 'sensuclassic', :type => :class do
           it { should contain_service('sensu-enterprise').that_subscribes_to('Class[sensuclassic::redis::config]') }
           it { should contain_service('sensu-enterprise').that_subscribes_to('Class[sensuclassic::rabbitmq::config]') }
           it { should contain_service('sensu-enterprise').that_subscribes_to('Class[sensuclassic::package]') }
+          it { should contain_exec('sensu-enterprise-reload').with_command('service sensu-enterprise reload') }
           it { should_not contain_yumrepo('sensu-enterprise-dashboard') }
           it { should contain_package('sensu-enterprise') }
 
@@ -249,6 +250,7 @@ describe 'sensuclassic', :type => :class do
           } }
           it { should contain_yumrepo('sensu-enterprise') }
           it { should contain_service('sensu-enterprise') }
+          it { should contain_exec('sensu-enterprise-reload') }
           it { should_not contain_yumrepo('sensu-enterprise-dashboard') }
           it { should_not contain_service('sensu-enterprise-dashboard') }
         end

--- a/spec/defines/sensuclassic_check_spec.rb
+++ b/spec/defines/sensuclassic_check_spec.rb
@@ -249,6 +249,11 @@ describe 'sensuclassic::check', :type => :define do
       let(:pre_condition) { 'class {"sensuclassic": client => true, api => true, server => true}' }
       it { should contain_sensuclassic__write_json(fpath).with(:notify_list => ['Service[sensu-client]', 'Class[Sensuclassic::Server::Service]', 'Service[sensu-api]']) }
     end
+
+    context 'client and enterprise' do
+      let(:pre_condition) { 'class {"sensuclassic": enterprise => true, enterprise_user => "sensu", enterprise_pass => "sensu"}' }
+      it { should contain_sensuclassic__write_json(fpath).with(:notify_list => ['Service[sensu-client]', 'Exec[sensu-enterprise-reload]']) }
+    end
   end
 
   context 'with subdue' do


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Execute a service reload for sensu-enterprise service rather than restart, when configurations change.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #17

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sensu Enterprise supports reloading configurations instead of a full restart and the configurations will be checked which means bad configurations won't leave the service stopped upon failure.