### PR TITLE
Add check_name for checks

### DIFF
--- a/lib/puppet/provider/sensuclassic_check/json.rb
+++ b/lib/puppet/provider/sensuclassic_check/json.rb
@@ -72,11 +72,11 @@ Puppet::Type.type(:sensuclassic_check).provide(:json) do
 
   def pre_create
     conf['checks'] = {}
-    conf['checks'][resource[:name]] = {}
+    conf['checks'][resource[:check_name]] = {}
   end
 
   def sort_properties!
-    conf['checks'][resource[:name]] = Hash[conf['checks'][resource[:name]].sort]
+    conf['checks'][resource[:check_name]] = Hash[conf['checks'][resource[:check_name]].sort]
   end
 
   def is_property?(prop)
@@ -84,12 +84,12 @@ Puppet::Type.type(:sensuclassic_check).provide(:json) do
   end
 
   def custom
-    conf['checks'][resource[:name]].reject { |k,v| is_property?(k) }
+    conf['checks'][resource[:check_name]].reject { |k,v| is_property?(k) }
   end
 
   def custom=(value)
-    conf['checks'][resource[:name]].delete_if { |k,v| not is_property?(k) }
-    conf['checks'][resource[:name]].merge!(to_type(value))
+    conf['checks'][resource[:check_name]].delete_if { |k,v| not is_property?(k) }
+    conf['checks'][resource[:check_name]].merge!(to_type(value))
   end
 
   def destroy
@@ -97,7 +97,7 @@ Puppet::Type.type(:sensuclassic_check).provide(:json) do
   end
 
   def exists?
-    conf.has_key?('checks') and conf['checks'].has_key?(resource[:name])
+    conf.has_key?('checks') and conf['checks'].has_key?(resource[:check_name])
   end
 
   def config_file
@@ -121,15 +121,15 @@ Puppet::Type.type(:sensuclassic_check).provide(:json) do
   end
 
   def get_property(property)
-    value = conf['checks'][resource[:name]][property.to_s]
+    value = conf['checks'][resource[:check_name]][property.to_s]
     value.nil? ? :absent : value
   end
 
   def set_property(property, value)
     if value == :absent
-      conf['checks'][resource[:name]].delete(property.to_s)
+      conf['checks'][resource[:check_name]].delete(property.to_s)
     else
-      conf['checks'][resource[:name]][property.to_s] = value
+      conf['checks'][resource[:check_name]][property.to_s] = value
     end
   end
 end

--- a/lib/puppet/type/sensuclassic_check.rb
+++ b/lib/puppet/type/sensuclassic_check.rb
@@ -47,6 +47,13 @@ Puppet::Type.newtype(:sensuclassic_check) do
     desc "The name of the check."
   end
 
+  newparam(:check_name) do
+    desc "The name of the check, defaults to value of `name`"
+    defaultto do
+      @resource[:name]
+    end
+  end
+
   newproperty(:command) do
     desc "Command to be run by the check"
     newvalues(/.*/, :absent)

--- a/spec/defines/sensuclassic_check_spec.rb
+++ b/spec/defines/sensuclassic_check_spec.rb
@@ -502,4 +502,16 @@ describe 'sensuclassic::check', :type => :define do
     end
   end
 
+  describe 'check_name' do
+    context 'check_name defined' do
+      let(:params_override) do
+        { check_name: 'testcheck' }
+      end
+      let(:expected_content_new) do
+        check =  expected_content['checks']['mycheck']
+        { 'checks' => { 'testcheck' => check } }
+      end
+      it { should contain_sensuclassic__write_json(fpath).with_content(expected_content_new) }
+    end
+  end
 end

--- a/spec/unit/sensuclassic_check_spec.rb
+++ b/spec/unit/sensuclassic_check_spec.rb
@@ -11,6 +11,17 @@ describe Puppet::Type.type(:sensuclassic_check) do
   let(:resource_hash_override) { {} }
   let(:resource_hash) { resource_hash_base.merge(resource_hash_override) }
 
+  describe 'check_name parameter' do
+    subject { described_class.new(resource_hash)[:check_name] }
+    it 'defaults to name' do
+      is_expected.to eq resource_hash[:title]
+    end
+    describe 'check_name defined' do
+      let(:resource_hash_override) { { check_name: 'foo' } }
+      it { is_expected.to eq 'foo' }
+    end
+  end
+
   describe 'contacts parameter' do
     subject { described_class.new(resource_hash)[:contacts] }
 


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds `check_name` parameter to `sensuclassic::check` and `check_name` property to `sensuclassic_check`.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

This is a continuation of #16 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows multiple checks to be defined with same name.
