### PR TITLE
Revert check_name changes

### DIFF
--- a/lib/puppet/provider/sensuclassic_check/json.rb
+++ b/lib/puppet/provider/sensuclassic_check/json.rb
@@ -72,11 +72,11 @@ Puppet::Type.type(:sensuclassic_check).provide(:json) do
 
   def pre_create
     conf['checks'] = {}
-    conf['checks'][resource[:check_name]] = {}
+    conf['checks'][resource[:name]] = {}
   end
 
   def sort_properties!
-    conf['checks'][resource[:check_name]] = Hash[conf['checks'][resource[:check_name]].sort]
+    conf['checks'][resource[:name]] = Hash[conf['checks'][resource[:name]].sort]
   end
 
   def is_property?(prop)
@@ -84,12 +84,12 @@ Puppet::Type.type(:sensuclassic_check).provide(:json) do
   end
 
   def custom
-    conf['checks'][resource[:check_name]].reject { |k,v| is_property?(k) }
+    conf['checks'][resource[:name]].reject { |k,v| is_property?(k) }
   end
 
   def custom=(value)
-    conf['checks'][resource[:check_name]].delete_if { |k,v| not is_property?(k) }
-    conf['checks'][resource[:check_name]].merge!(to_type(value))
+    conf['checks'][resource[:name]].delete_if { |k,v| not is_property?(k) }
+    conf['checks'][resource[:name]].merge!(to_type(value))
   end
 
   def destroy
@@ -97,7 +97,7 @@ Puppet::Type.type(:sensuclassic_check).provide(:json) do
   end
 
   def exists?
-    conf.has_key?('checks') and conf['checks'].has_key?(resource[:check_name])
+    conf.has_key?('checks') and conf['checks'].has_key?(resource[:name])
   end
 
   def config_file
@@ -121,15 +121,15 @@ Puppet::Type.type(:sensuclassic_check).provide(:json) do
   end
 
   def get_property(property)
-    value = conf['checks'][resource[:check_name]][property.to_s]
+    value = conf['checks'][resource[:name]][property.to_s]
     value.nil? ? :absent : value
   end
 
   def set_property(property, value)
     if value == :absent
-      conf['checks'][resource[:check_name]].delete(property.to_s)
+      conf['checks'][resource[:name]].delete(property.to_s)
     else
-      conf['checks'][resource[:check_name]][property.to_s] = value
+      conf['checks'][resource[:name]][property.to_s] = value
     end
   end
 end

--- a/lib/puppet/type/sensuclassic_check.rb
+++ b/lib/puppet/type/sensuclassic_check.rb
@@ -47,13 +47,6 @@ Puppet::Type.newtype(:sensuclassic_check) do
     desc "The name of the check."
   end
 
-  newparam(:check_name) do
-    desc "The name of the check, defaults to value of `name`"
-    defaultto do
-      @resource[:name]
-    end
-  end
-
   newproperty(:command) do
     desc "Command to be run by the check"
     newvalues(/.*/, :absent)

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -2,12 +2,6 @@
 #
 # This define manages Sensu checks
 #
-# @param check_name The name of the check.
-#   If not specified, defaults to the name of the resource. Overriding it
-#   allows the check name to differ from the check configuration filename,
-#   useful when having checks of the same name from different proxy clients.
-#   (see the 'source' parameter)
-#
 # @param command The check command to run
 #
 # @param ensure Whether the check should be present or not.
@@ -108,7 +102,6 @@
 #   of the Hash value.
 #
 define sensuclassic::check (
-  Optional[String] $check_name = undef,
   Optional[String] $command = undef,
   Enum['present','absent'] $ensure = 'present',
   Optional[String] $type = undef,
@@ -160,11 +153,7 @@ define sensuclassic::check (
     }
   }
 
-  $check_file_name = regsubst(regsubst($name, ' ', '_', 'G'), '[\(\)]', '', 'G')
-  $check_config_name = $check_name ? {
-    undef   => $check_file_name,
-    default => $check_name,
-  }
+  $check_name = regsubst(regsubst($name, ' ', '_', 'G'), '[\(\)]', '', 'G')
 
   # If cron is specified, interval should not be written to the configuration
   if $cron and $cron != 'absent' {
@@ -214,7 +203,7 @@ define sensuclassic::check (
     }
   }
 
-  # This Hash map will ultimately exist at `{"checks" => {"$check_config_name" =>
+  # This Hash map will ultimately exist at `{"checks" => {"$check_name" =>
   # $check_config}}`
   $check_config_start = {
     type                => $type,
@@ -262,7 +251,7 @@ define sensuclassic::check (
 
   # Merge together the "checks" scope with any arbitrary config specified via
   # `content`.
-  $checks_scope_start = { $check_config_name => $check_config }
+  $checks_scope_start = { $check_name => $check_config }
   if $content['checks'] == undef {
     $checks_scope = { 'checks' => $checks_scope_start }
   } else {
@@ -273,7 +262,7 @@ define sensuclassic::check (
   # on top of any arbitrary plugin and extension configuration in $content.
   $content_real = $content + $checks_scope
 
-  sensuclassic::write_json { "${sensuclassic::conf_dir}/checks/${check_file_name}.json":
+  sensuclassic::write_json { "${sensuclassic::conf_dir}/checks/${check_name}.json":
     ensure      => $ensure,
     content     => $content_real,
     owner       => $sensuclassic::user,

--- a/spec/defines/sensuclassic_check_spec.rb
+++ b/spec/defines/sensuclassic_check_spec.rb
@@ -507,16 +507,4 @@ describe 'sensuclassic::check', :type => :define do
     end
   end
 
-  describe 'check_name' do
-    context 'check_name defined' do
-      let(:params_override) do
-        { check_name: 'testcheck' }
-      end
-      let(:expected_content_new) do
-        check =  expected_content['checks']['mycheck']
-        { 'checks' => { 'testcheck' => check } }
-      end
-      it { should contain_sensuclassic__write_json(fpath).with_content(expected_content_new) }
-    end
-  end
 end

--- a/spec/unit/sensuclassic_check_spec.rb
+++ b/spec/unit/sensuclassic_check_spec.rb
@@ -11,17 +11,6 @@ describe Puppet::Type.type(:sensuclassic_check) do
   let(:resource_hash_override) { {} }
   let(:resource_hash) { resource_hash_base.merge(resource_hash_override) }
 
-  describe 'check_name parameter' do
-    subject { described_class.new(resource_hash)[:check_name] }
-    it 'defaults to name' do
-      is_expected.to eq resource_hash[:title]
-    end
-    describe 'check_name defined' do
-      let(:resource_hash_override) { { check_name: 'foo' } }
-      it { is_expected.to eq 'foo' }
-    end
-  end
-
   describe 'contacts parameter' do
     subject { described_class.new(resource_hash)[:contacts] }
 


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Revert "Add parameter sensuclassic::check::check_name"
Revert "Add check_name property to sensuclassic_check"
Revert "Add unit test for sensuclassic::check check_name parameter"

This reverts commit 57ecfcfc1987ff96ed566efd477b5262bad8fe90.
This reverts commit 45aab3e0e99ba26233d25149069b92d19482add9
This reverts commit 9e6441500e00d5d0cdbf329f6720ddc6ba0f829b

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Based on comments in #19 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Seems checks with same name in different files doesn't actually work so this reverts the ability to have checks with different names than file.
