### PR TITLE
CI updates for Travis ruby versions and use latest Rake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,102 +18,102 @@ script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec 
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.4.4
+  - rvm: 2.4.9
     env: PUPPET_GEM_VERSION="~> 5"
     bundler_args: --without system_tests development
-  - rvm: 2.4.4
+  - rvm: 2.4.9
     env: PUPPET_GEM_VERSION="~> 5" FIXTURES_YML=".fixtures-latest.yml"
     bundler_args: --without system_tests development
-  - rvm: 2.5.3
+  - rvm: 2.5.7
     env: PUPPET_GEM_VERSION="~> 6"
     bundler_args: --without system_tests development
-  - rvm: 2.5.3
+  - rvm: 2.5.7
     env: PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-latest.yml"
     bundler_args: --without system_tests development
-  - rvm: 2.4.4
+  - rvm: 2.4.9
     sudo: required
     services: docker
     env: BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
-  - rvm: 2.5.3
+  - rvm: 2.5.7
     sudo: required
     services: docker
     env: BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.9
     sudo: required
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
-  - rvm: 2.5.3
+  - rvm: 2.5.7
     sudo: required
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.9
     sudo: required
     services: docker
     env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
-  - rvm: 2.5.3
+  - rvm: 2.5.7
     sudo: required
     services: docker
     env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.9
     sudo: required
     services: docker
     env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
-  - rvm: 2.5.3
+  - rvm: 2.5.7
     sudo: required
     services: docker
     env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.9
     sudo: required
     services: docker
     env: BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
-  - rvm: 2.5.3
+  - rvm: 2.5.7
     sudo: required
     services: docker
     env: BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.9
     sudo: required
     services: docker
     env: BEAKER_set="ubuntu-1804" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
-  - rvm: 2.5.3
+  - rvm: 2.5.7
     sudo: required
     services: docker
     env: BEAKER_set="ubuntu-1804" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.9
     sudo: required
     services: docker
     env: BEAKER_set="amazonlinux-201803" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
-  - rvm: 2.5.3
+  - rvm: 2.5.7
     sudo: required
     services: docker
     env: BEAKER_set="amazonlinux-201803" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.9
     sudo: required
     services: docker
     env: BEAKER_set="amazonlinux-2" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
-  - rvm: 2.5.3
+  - rvm: 2.5.7
     sudo: required
     services: docker
     env: BEAKER_set="amazonlinux-2" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
 allow_failures:
-  - rvm: 2.4.4
+  - rvm: 2.4.9
     env: PUPPET_GEM_VERSION="~> 5" FIXTURES_YML=".fixtures-latest.yml"
-  - rvm: 2.5.3
+  - rvm: 2.5.7
     env: PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-latest.yml"
 branches:
   only:

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ else
 end
 
 group :development, :unit_tests do
-  gem 'rake',                                             '< 11.0.0'
+  gem 'rake'
   gem 'rspec-puppet', '~> 2.6.0',                         :require => false
   gem 'rspec-mocks',                                      :require => false
   gem 'puppetlabs_spec_helper', '>= 2.11.0',               :require => false


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update travis matrix to use Ruby that's part of latest puppet-agent and remove version restriction on Rake.
