### PR TITLE
(GH-29) Removes validate_bool() usage

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -447,7 +447,7 @@ class sensuclassic (
   Variant[String,Array,Hash] $plugins = [],
   Hash $plugins_defaults = {},
   Optional[String] $plugins_dir = undef,
-  Variant[Boolean,Hash] $purge = false,
+  Variant[Boolean,Hash[Enum['plugins','config','handlers','extensions','mutators'],Boolean]] $purge = false,
   Boolean $purge_config = false,
   Boolean $purge_plugins_dir = false,
   Boolean $use_embedded_ruby = true,
@@ -628,7 +628,6 @@ class sensuclassic (
     # Default anything not specified to false
     $default_purge_hash = { plugins => false, config => false, handlers => false, extensions => false, mutators => false }
     $full_purge_hash = merge($default_purge_hash, $purge)
-    validate_bool($full_purge_hash['plugins'], $full_purge_hash['config'], $full_purge_hash['handlers'], $full_purge_hash['extensions'], $full_purge_hash['mutators'])
     # Check that all keys are valid
     $invalid_keys = difference(keys($purge), keys($default_purge_hash))
     if !empty($invalid_keys) {

--- a/spec/classes/sensuclassic_package_spec.rb
+++ b/spec/classes/sensuclassic_package_spec.rb
@@ -385,7 +385,7 @@ describe 'sensuclassic' do
         let(:params) { { :purge => { 'other_key' => true } } }
 
         it 'should fail' do
-          expect { should create_class('sensu') }.to raise_error(/Invalid keys for purge parameter/)
+          expect { should create_class('sensu') }.to raise_error(Puppet::PreformattedError)
         end
       end
     end


### PR DESCRIPTION
## Description
Replaces `validate_bool()` usage with Puppet Types

## Related Issue

Fixes #29  .

## Motivation and Context
Per the issue, the `validate_bool()` function is deprecated and produces a noisy warning in the puppetserver logs.

## How Has This Been Tested?
There is a unit test that covers the type checking.  I updated the exception, but the tests still pass.

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
