### PR TITLE
Better proxy support for installing on Windows

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,7 +9,7 @@ fixtures:
       puppet_version: ">= 6.0.0"
     stdlib:
       repo: git://github.com/puppetlabs/puppetlabs-stdlib.git
-      ref: 4.24.0
+      ref: 4.25.0
     remote_file:
       repo: git://github.com/lwf/puppet-remote_file.git
       ref: v1.1.3

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -297,6 +297,12 @@
 #
 # @param package_checksum Used to set package_checksum for windows installs
 #
+# @param package_proxy_host
+#   Package proxy host. Currently only used applies to Windows not using chocolatey.
+#
+# @param package_proxy_port
+#   Package proxy port. Currently only used applies to Windows not using chocolatey.
+#
 # @param windows_logrotate Whether or not to use logrotate on Windows OS family.
 #
 # @param windows_log_size The integer value for the size of log files on
@@ -479,6 +485,8 @@ class sensuclassic (
   Boolean $deregister_on_stop = false,
   Optional[String] $deregister_handler = undef,
   Optional[String] $package_checksum = undef,
+  Optional[String] $package_proxy_host = undef,
+  Optional[Stdlib::Port] $package_proxy_port = undef,
   Optional[String] $windows_pkg_url = undef,
   Optional[String] $windows_repo_prefix = 'https://eol-repositories.sensuapp.org/msi',
   Boolean $windows_logrotate = false,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -158,10 +158,12 @@ class sensuclassic::package (
 
         # path matches Package[sensu] { source => $pkg_source }
         remote_file { $pkg_title:
-          ensure   => present,
-          path     => $pkg_source,
-          source   => $pkg_url,
-          checksum => $sensuclassic::package_checksum,
+          ensure     => present,
+          path       => $pkg_source,
+          source     => $pkg_url,
+          checksum   => $sensuclassic::package_checksum,
+          proxy_host => $sensuclassic::package_proxy_host,
+          proxy_port => $sensuclassic::package_proxy_port,
         }
       }
     }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -29,6 +29,12 @@
 #   See: https://docs.puppetlabs.com/references/latest/type.html#package-attribute-install_options
 #   Example value: [{ '-p' => 'http://user:pass@myproxy.company.org:8080' }]
 #
+# @param pkg_proxy_host
+#   The proxy host used to download the plugin when `type` is `url`
+#
+# @param pkg_proxy_port
+#   The proxy port used to download the plugin when `type` is `url`
+#
 define sensuclassic::plugin (
   Enum['file','url','package','directory'] $type = 'file',
   Stdlib::Absolutepath $install_path = $::osfamily ? {
@@ -43,6 +49,8 @@ define sensuclassic::plugin (
   Optional[String] $pkg_checksum = undef,
   Boolean $nocheckcertificate  = false,
   Any $gem_install_options = $sensuclassic::gem_install_options,
+  Optional[String] $pkg_proxy_host = $sensuclassic::package_proxy_host,
+  Optional[Stdlib::Port] $pkg_proxy_port = $sensuclassic::package_proxy_port,
 ) {
 
   File {
@@ -87,11 +95,13 @@ define sensuclassic::plugin (
       }
 
       remote_file { $name:
-        ensure   => present,
-        path     => "${install_path}/${filename}",
-        source   => $name,
-        checksum => $pkg_checksum,
-        require  => File[$install_path],
+        ensure     => present,
+        path       => "${install_path}/${filename}",
+        source     => $name,
+        checksum   => $pkg_checksum,
+        proxy_host => $pkg_proxy_host,
+        proxy_port => $pkg_proxy_port,
+        require    => File[$install_path],
       }
 
       file { "${install_path}/${filename}":

--- a/metadata.json
+++ b/metadata.json
@@ -75,7 +75,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.24.0 <7.0.0"
+      "version_requirement": ">=4.25.0 <7.0.0"
     }
   ]
 }

--- a/spec/classes/sensuclassic_package_spec.rb
+++ b/spec/classes/sensuclassic_package_spec.rb
@@ -487,6 +487,19 @@ describe 'sensuclassic' do
         end
       end
 
+      context 'with package_proxy_host and package_proxy_port specified' do
+        let(:params) do
+          { package_proxy_host: 'example.com', package_proxy_port: 3218 }
+        end
+
+        it 'overrides computation using windows_repo_prefix' do
+          should contain_remote_file('sensu').with(
+            proxy_host: 'example.com',
+            proxy_port: 3218,
+          )
+        end
+      end
+
       context 'with sensuclassic::windows_package_provider: chocolatey' do
         let(:params) do
           { windows_package_provider: 'chocolatey' }

--- a/spec/defines/sensuclassic_plugin_spec.rb
+++ b/spec/defines/sensuclassic_plugin_spec.rb
@@ -155,6 +155,21 @@ describe 'sensuclassic::plugin', :type => :define do
         :source   => 'https://raw.githubusercontent.com/sensu-plugins/sensu-plugins-puppet/master/bin/check-puppet-last-run.rb'
       ) }
     end
+
+    context 'install via proxy' do
+      let(:params) { {
+        :type           => 'url',
+        :pkg_proxy_host => 'example.com',
+        :pkg_proxy_port => 3218,
+      } }
+
+      it { should contain_remote_file('https://raw.githubusercontent.com/sensu/sensu-community-plugins/master/plugins/system/check-mem.sh').with(
+        :ensure     => 'present',
+        :path       => '/etc/sensu/plugins/check-mem.sh',
+        :proxy_host => 'example.com',
+        :proxy_port => 3218,
+      ) }
+    end
   end
 
   context 'directory' do


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add better proxy support when installing on Windows not using chocolately
Also add better proxy support for installing plugins via URL

* Add package_proxy_host and package_proxy_port to sensuclassic
* Add pkg_proxy_host and pkg_proxy_port to sensuclassic::plugin

Required bump of stdlib minimum to be 4.25.0 to get `Stdlib::Port`.