### PR TITLE
Fix dsc_service order issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ end
 group :documentation do
   gem 'yard',           require: false
   gem 'redcarpet',      require: false
-  gem 'puppet-strings', require: false
+  gem 'puppet-strings', '~> 2.4.0',  require: false
 end
 
 group :system_tests do

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ end
 
 group :development, :unit_tests do
   gem 'rake'
-  gem 'rspec-puppet', '~> 2.6.0',                         :require => false
+  gem 'rspec-puppet',                                     :require => false
   gem 'rspec-mocks',                                      :require => false
   gem 'puppetlabs_spec_helper', '>= 2.11.0',               :require => false
   gem 'puppet-lint', "~> 2.0",                            :require => false

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -78,7 +78,12 @@ class sensuclassic::client (
           dsc_credential  => $sensuclassic::windows_service_user,
           dsc_displayname => 'Sensu Client',
           dsc_path        => 'c:\\opt\\sensu\\bin\\sensu-client.exe',
-          require         => File['C:/opt/sensu/bin/sensu-client.xml'],
+          require         => [
+            File['C:/opt/sensu/bin/sensu-client.xml'],
+            Class['sensuclassic::package'],
+            Sensuclassic_client_config[$::fqdn],
+            Class['sensuclassic::rabbitmq::config'],
+          ],
           notify          => Service['sensu-client'],
         }
       }

--- a/spec/classes/sensuclassic_service_spec.rb
+++ b/spec/classes/sensuclassic_service_spec.rb
@@ -73,7 +73,12 @@ describe 'sensuclassic', :type => :class do
               'dsc_displayname' => 'Sensu Client',
               'dsc_path'        => 'c:\\opt\\sensu\\bin\\sensu-client.exe',
               'notify'          => 'Service[sensu-client]',
-              'require'         => 'File[C:/opt/sensu/bin/sensu-client.xml]',
+              'require'         => [
+                'File[C:/opt/sensu/bin/sensu-client.xml]',
+                'Class[Sensuclassic::Package]',
+                'Sensuclassic_client_config[testfqdn.example.com]',
+                'Class[Sensuclassic::Rabbitmq::Config]',
+              ],
             })
           end
 


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix DSC service order of operations.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #32

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It seems that `dsc_service` is starting the service, not `Service['sensu-client']` so this ensures that configs and other necessary items are in place before adding the DSC service.
