### PR TITLE
Fix windows service management

### DIFF
--- a/tests/sensu-client-windows.pp
+++ b/tests/sensu-client-windows.pp
@@ -1,6 +1,6 @@
 # Note: Check http://repositories.sensuapp.org/msi/ for the latest version.
 class { 'sensuclassic':
-  version           => '0.29.0-11',
+  version           => '1.8.0-1',
   rabbitmq_password => 'correct-horse-battery-staple',
   rabbitmq_host     => '192.168.156.10',
   rabbitmq_vhost    => '/sensu',


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace dsc_service with Exec that installs the sensu-client service. All parameter behaviors are the same, the only change is how the service gets installed.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #33


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This more closely matches the steps documented by Sensu for installing the client service on Windows.
