### PR TITLE
Fix for Windows when client => false

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -31,10 +31,12 @@ class sensuclassic::client (
       true: {
         $service_ensure = $client_service_ensure
         $service_enable = $client_service_enable
+        $before_install_service = Exec['install-sensu-client-service']
       }
       default: {
         $service_ensure = 'stopped'
         $service_enable = false
+        $before_install_service = undef
       }
     }
     case $::osfamily {
@@ -52,7 +54,7 @@ class sensuclassic::client (
             dsc_ensure   => present,
             dsc_policy   => 'Log_on_as_a_service',
             dsc_identity => $sensuclassic::windows_service_user['user'],
-            before       => Exec['install-sensu-client-service'],
+            before       => $before_install_service,
           }
 
           acl { 'C:/opt/sensu':
@@ -63,7 +65,7 @@ class sensuclassic::client (
                 'rights'   => ['full'],
               },
             ],
-            before      => Exec['install-sensu-client-service'],
+            before      => $before_install_service,
           }
 
           $service_user = $sensuclassic::windows_service_user['user']

--- a/spec/classes/sensuclassic_service_spec.rb
+++ b/spec/classes/sensuclassic_service_spec.rb
@@ -110,6 +110,12 @@ describe 'sensuclassic', :type => :class do
               'before'      => 'Exec[install-sensu-client-service]',
             })
           end
+
+          context 'with client => false' do
+            let(:params) { { :client => false, :windows_service_user => { 'user' => 'test', 'password' => 'test' }} }
+            it { should contain_acl('C:/opt/sensu') }
+            it { should_not contain_exec('install-sensu-client-service') }
+          end
         end
 
         context 'with log_level => debug' do


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Resolves an issue of undefined resources when `client => false` on Windows and DSC user is defined.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #36